### PR TITLE
fix ValueError in default MENUITEMS

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -58,7 +58,7 @@
             {% endif %}
         </div>
         <div id="nav-menu">
-            {% set MENUS_TMP = MENUITEMS or (('Home', '/.', 'fa-home'), ('Archive', '/archives.html', 'fa-archive')) %}
+            {% set MENUS_TMP = MENUITEMS or (('Home', '/.', 'fa-home', 'index'), ('Archive', '/archives.html', 'fa-archive', 'archive')) %}
             {% for title, link, fa, current_name in MENUS_TMP %}
             <a href="{{ link }}" {% if current_name == page_name %}class="current"{% endif %}>
                 <i class="fa {{ fa }}"> {{ title }}</i></a>


### PR DESCRIPTION
When no MENUITEMS is specified and using default, it would throw a ValueError, because the next line is expecting 4-tuples ` title, link, fa, current_name` while the default value gives two 3-tuples ` (('Home', '/.', 'fa-home', 'index'), ('Archive', '/archives.html', 'fa-archive', 'archive'))`.

This change fixes it by changing the default to 4-tuples.
